### PR TITLE
Fix #17 - "Config directories aren't correctly created on Windows"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 **/*.rs.bk
+.vscode/

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,51 @@
+use std::{fs, env};
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use xdg;
+
+use error::Error;
+
+
+#[cfg(unix)]
+pub fn get_feed_path(name: &str) -> Result<PathBuf, Error> {
+    let path = format!("feeds/{}.feed", name);
+    Ok(xdg::BaseDirectories::with_prefix(::APP_NAME)
+        .map_err(|e| Error::Msg(format!("{}", e)))?
+        .place_data_file(&path)
+        .map_err(|e| Error::Msg(format!("{}", e)))?)
+}
+
+#[cfg(unix)]
+pub fn get_config_path() -> Result<PathBuf, Error> {
+    Ok(xdg::BaseDirectories::with_prefix(::APP_NAME)
+        .map_err(|e| Error::Msg(format!("{}", e)))?
+        .place_config_file("config.feeds")
+        .map_err(|e| Error::Msg(format!("{}", e)))?)
+}
+
+#[cfg(windows)]
+fn app_data_dir() -> Result<PathBuf, Error> {
+    if let Some(app_data_dir) = env::var_os("APPDATA") {
+        Ok(Path::new(&app_data_dir).join("Feedburst"))
+    } else {
+        Err(Error::Msg("Unable to find the APPDATA directory".into()))
+    }
+}
+
+#[cfg(windows)]
+pub fn get_feed_path(name: &str) -> Result<PathBuf, Error> {
+    let path = app_data_dir()?.join("feeds");
+    fs::create_dir_all(&path)
+        .map_err(|_| Error::Msg(format!("Error creating directory {:?}", path)))?;
+    let fname = format!("{}.feed", name);
+    Ok(path.join(fname))
+}
+
+#[cfg(windows)]
+pub fn get_config_path() -> Result<PathBuf, Error> { 
+    let path = app_data_dir()?;
+    fs::create_dir_all(&path)
+        .map_err(|_| Error::Msg(format!("Error creating directory {:?}", path)))?;
+    Ok(path.join("config.feeds"))
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,5 @@
 use std::{io, fmt};
 use reqwest;
-#[cfg(unix)]
-use xdg;
-#[cfg(windows)]
-use app_dirs;
 
 #[derive(Debug)]
 pub enum Error {
@@ -71,19 +67,5 @@ impl From<io::Error> for Error {
 impl From<reqwest::Error> for Error {
     fn from(err: reqwest::Error) -> Error {
         Error::Request(err)
-    }
-}
-
-#[cfg(unix)]
-impl From<xdg::BaseDirectoriesError> for Error {
-    fn from(err: xdg::BaseDirectoriesError) -> Error {
-        Error::Msg(format!("{}", err))
-    }
-}
-
-#[cfg(windows)]
-impl From<app_dirs::AppDirsError> for Error {
-    fn from(err: app_dirs::AppDirsError) -> Error {
-        Error::Msg(format!("{}", err))
     }
 }


### PR DESCRIPTION
Refactor the source of the config paths into a seperate "config" module.