### PR TITLE
Fix #33 - Feeds are marked as read even if they fail to open

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -253,7 +253,10 @@ fn read_feed(feed: &mut Feed) -> Result<(), Error> {
     }
     let plural_feeds = if items.len() == 1 { "comic" } else { "comics" };
     println!("{} ({} {})", feed.info.name, items.len(), plural_feeds);
-    open::that(items.first().unwrap())?;
+    let status = open::that(items.first().unwrap())?;
+    if !status.success() {
+        return Err(Error::Msg("Failed to open feed".into()));
+    }
     feed.read();
     feed.write_changes(&mut file)?;
     Ok(())


### PR DESCRIPTION
The `open` crate returns Ok() as long as there's not an I/O error, which means
it's returning Ok(EXIT_FAILURE) when the open command fails. We check the error
code now, and properly avoid marking the comic as read if the open failed.