### PR TITLE
Crates.io release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,18 +1,3 @@
-[root]
-name = "feedburst"
-version = "0.3.0"
-dependencies = [
- "app_dirs 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "open 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pretty_env_logger 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syndication 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "RustyXML"
 version = "0.1.1"
@@ -165,6 +150,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "feedburst"
+version = "0.3.0"
+dependencies = [
+ "app_dirs 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "open 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pretty_env_logger 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syndication 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0+"
 readme = "README.md"
 keywords = ["comic", "rss", "atom", "syndication"]
 categories = ["command-line-utilities"]
-publish = false
+publish = true
 description = """
 A tool to consume comic RSS feeds and present them to you in bunches, on a schedule of your choosing.
 """

--- a/README.md
+++ b/README.md
@@ -4,8 +4,18 @@
 [![Build Status](https://travis-ci.org/porglezomp/feedburst.svg)](https://travis-ci.org/porglezomp/feedburst)
 [![Coverage Status](https://coveralls.io/repos/github/porglezomp/feedburst/badge.svg?branch=develop)](https://coveralls.io/github/porglezomp/feedburst?branch=develop)
 [![Release](https://img.shields.io/github/release/porglezomp/feedburst.svg)](https://github.com/porglezomp/feedburst/releases/latest)
+[![Crates.io](https://img.shields.io/crates/v/feedburst.svg)](https://crates.io/crates/feedburst)
 
 Feedburst is a tool that presents you your RSS feeds in chunks, according to a policy that you set.
+
+## Installing
+
+You can install Feedburst by going to the releases page and downloading the latest release for your platform.
+If you have `cargo` already installed, you can also get it by running:
+
+```
+cargo install feedburst
+```
 
 ## Configuring
 


### PR DESCRIPTION
Release on crates.io and add a version badge.

Closes #47 