### PR TITLE
Change feeds to use local datetime

### DIFF
--- a/src/feed.rs
+++ b/src/feed.rs
@@ -181,7 +181,7 @@ impl Feed {
                     trace!("Rule for \"{}\": @ on {:?}", self.info.name, day);
                     day_relevant = true;
                     use chrono::Datelike;
-                    let mut last_day = self.last_read.weekday();
+                    let mut last_day = last_read.weekday();
                     for _ in 0..elapsed_time.num_days() {
                         last_day = last_day.succ();
                         if last_day == day {

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc, Weekday, MIN_DATE};
+use chrono::{DateTime, Utc, Local, Weekday, MIN_DATE};
 use regex::Regex;
 use std::collections::HashSet;
 use std::io::{self, Read, Seek, Write};
@@ -157,7 +157,8 @@ impl Feed {
     }
 
     pub fn is_scheduled(&self) -> bool {
-        let elapsed_time = Utc::now().signed_duration_since(self.last_read);
+        let last_read = self.last_read.with_timezone(&Local);
+        let elapsed_time = Local::now().signed_duration_since(last_read);
         let mut day_passed = false;
         let mut day_relevant = false;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ extern crate xdg;
 use std::io::Read;
 use std::str::FromStr;
 
+use chrono::Local;
 use clap::{App, Arg};
 
 mod config;
@@ -136,7 +137,7 @@ fn run() -> Result<(), Error> {
         .collect();
 
     // Fetch the feeds that are currently scheduled, not those that are unscheduled
-    feeds.sort_by_key(|feed| !feed.is_scheduled());
+    feeds.sort_by_key(|feed| !feed.is_scheduled(Local::now()));
 
     let rx = {
         let (tx, rx) = std::sync::mpsc::channel();


### PR DESCRIPTION
Internally the Feed struct uses Utc datetimes converted from local datetimes.
Datetime stored in feed files are always stored as local.

The basic process is:
- Feed is read from feed file with local datetime (FeedEvent::read).
- This is then converted to Feed struct which internally stores datetime as Utc
- When we want to know if feed is scheduled, we find the duration from Utc datetime to Local datetime (this is handled by chrono).

I must say the test_parse_events test, gave me pretty hard time to fix, I could not find simple way to get the offset from Utc datetime to Local datetime in chrono crate, but it works now.

Fixes #58 